### PR TITLE
Patch: Detect default Downloads folder

### DIFF
--- a/com.tonikelope.MegaBasterd.yaml
+++ b/com.tonikelope.MegaBasterd.yaml
@@ -1,6 +1,6 @@
 app-id: com.tonikelope.MegaBasterd
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17

--- a/com.tonikelope.MegaBasterd.yaml
+++ b/com.tonikelope.MegaBasterd.yaml
@@ -57,6 +57,9 @@ modules:
       - type: file
         path: icon-256.png
       - maven-dependencies.yaml
+      # https://github.com/tonikelope/megabasterd/pull/464
+      - type: patch
+        path: detect-default-downloads-folder.patch
     modules:
       - name: openjdk
         buildsystem: simple

--- a/detect-default-downloads-folder.patch
+++ b/detect-default-downloads-folder.patch
@@ -1,0 +1,64 @@
+From 2d1b38d4a58341aa496fe690d10b8c91d965e65f Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Tue, 4 Oct 2022 04:12:56 -0300
+Subject: [PATCH] Linux: Use `xdg-user-dir` to get the default Downloads folder
+ path
+
+---
+ .../com/tonikelope/megabasterd/MainPanel.java | 22 ++++++++++++++++++-
+ .../megabasterd/SettingsDialog.java           |  2 +-
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/src/main/java/com/tonikelope/megabasterd/MainPanel.java b/src/main/java/com/tonikelope/megabasterd/MainPanel.java
+index 211e5ea69..0b3359dcf 100644
+--- a/src/main/java/com/tonikelope/megabasterd/MainPanel.java
++++ b/src/main/java/com/tonikelope/megabasterd/MainPanel.java
+@@ -18,6 +18,8 @@
+ import java.awt.event.ActionListener;
+ import java.awt.event.WindowEvent;
+ import static java.awt.event.WindowEvent.WINDOW_CLOSING;
++import java.io.BufferedReader;
++import java.io.InputStreamReader;
+ import java.io.File;
+ import java.io.FileNotFoundException;
+ import java.io.FileOutputStream;
+@@ -680,7 +682,25 @@ public void loadUserSettings() {
+         _default_download_path = selectSettingValue("default_down_dir");
+ 
+         if (_default_download_path == null) {
+-            _default_download_path = ".";
++            _default_download_path = Paths.get(".").toAbsolutePath().normalize().toString();
++            // On most Linux distributions, we can find the path of the default 'Downloads' directory with:
++            // $ xdg-user-dir DOWNLOAD
++            if (System.getProperty("os.name").toLowerCase().contains("nux")) {
++                try {
++                    Process p = Runtime.getRuntime().exec(new String[] { "xdg-user-dir", "DOWNLOAD" });
++                    BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
++                    // We only read a single line from the command output and then exit.
++                    String path = in.readLine();
++                    p.destroy();
++
++                    if (new File(path).isDirectory()) {
++                        _default_download_path = path;
++                    }
++                } catch (Exception ex) {
++                    Logger.getLogger(MainPanel.class.getName()).log(Level.WARNING, "Unable to get default Downloads folder: {0}", ex.getMessage());
++                }
++            }
++            Logger.getLogger(MainPanel.class.getName()).log(Level.INFO, "Downloads folder not set, using this one as default: {0}", _default_download_path);
+         }
+ 
+         String limit_dl_speed = selectSettingValue("limit_download_speed");
+diff --git a/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java b/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
+index 8dbb9aa01..028c6f4f3 100644
+--- a/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
++++ b/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
+@@ -174,7 +174,7 @@ public SettingsDialog(MainPanelView parent, boolean modal) {
+ 
+             String default_download_dir = DBTools.selectSettingValue("default_down_dir");
+ 
+-            default_download_dir = Paths.get(default_download_dir == null ? MainPanel.MEGABASTERD_HOME_DIR : default_download_dir).toAbsolutePath().normalize().toString();
++            default_download_dir = (default_download_dir == null ? _main_panel.getDefault_download_path() : default_download_dir);
+ 
+             _download_path = default_download_dir;
+ 

--- a/maven-dependencies.yaml
+++ b/maven-dependencies.yaml
@@ -1,1480 +1,1480 @@
 - type: file
   dest: .m2/repository/backport-util-concurrent/backport-util-concurrent/3.1
   url: https://repo.maven.apache.org/maven2/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom
-  sha1: 24aa8f29c14d1c63225caa6ad5328f1f7a2497a8
+  sha256: 770471090ca40a17b9e436ee2ec00819be42042da6f4085ece1d37916dc08ff9
 - type: file
   dest: .m2/repository/classworlds/classworlds/1.1
   url: https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.jar
-  sha1: 60c708f55deeb7c5dfce8a7886ef09cbc1388eca
+  sha256: 4e3e0ad158ec60917e0de544c550f31cd65d5a97c3af1c1968bf427e4a9df2e4
 - type: file
   dest: .m2/repository/classworlds/classworlds/1.1
   url: https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.pom
-  sha1: 4703c4199028094698c222c17afea6dcd9f04999
+  sha256: 25a1efc00bcd1f029fd20c44df843b8b12d1fa17485235470764f011d2f5cb29
 - type: file
   dest: .m2/repository/classworlds/classworlds/1.1-alpha-2
   url: https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar
-  sha1: 05adf2e681c57d7f48038b602f3ca2254ee82d47
+  sha256: 2bf4e59f3acd106fea6145a9a88fe8956509f8b9c0fdd11eb96fee757269e3f3
 - type: file
   dest: .m2/repository/classworlds/classworlds/1.1-alpha-2
   url: https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom
-  sha1: 8c8ad6a96a8c1168f8b12ec8a227b8261b160b26
+  sha256: 0cc647963b74ad1d7a37c9868e9e5a8f474e49297e1863582253a08a4c719cb1
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.6
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.6/jackson-annotations-2.12.6.jar
-  sha1: 9487231edd6b0b1f14692c9cba9e0462809215d1
+  sha256: ddf46e401a7d9ea3b481c263fa192285d13c50982a5882b22f806639b9645ee4
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.6
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.6/jackson-annotations-2.12.6.pom
-  sha1: f379297aae57895e00974d4cdb665084d167c6e3
+  sha256: dd8c672201d386d168cfe7140e8eb62643f44911681a0562254b7064957e61ab
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.6
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.6/jackson-core-2.12.6.jar
-  sha1: 5bf206c0b5982cfcd868b3d9349dc5190db8bab5
+  sha256: 0026cff293bdba389fbbbc67a20fdd5f73e091554ab46671efa654c25c807ee6
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.6
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.6/jackson-core-2.12.6.pom
-  sha1: 743e49a2d6979779acabfac4cb9a084a4d425ddf
+  sha256: 3d8b64316e38439de6e0f14131e6d7d58d74e924f03d313b3cd8292a966aa010
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.6.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.6.1/jackson-databind-2.12.6.1.jar
-  sha1: df01cc0c2d4acb913d73d587274986a12e3dec8c
+  sha256: eb60e494ba8c23e653da4db8e29af0342927fc7e1c60501bf99e93145738c696
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.6.1
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.6.1/jackson-databind-2.12.6.1.pom
-  sha1: f65b9a5c380220f0aad6e1766388d2481f80b5f7
+  sha256: a1a0c5fe17371116348e69c7a97a1b2ef265962d75e8023eec1409d8878c2c11
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-base/2.12.6
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.12.6/jackson-base-2.12.6.pom
-  sha1: 237d2f21ff3a8a33c403d79ae920e65aff6485ff
+  sha256: 71999f597522e5f50eb41474ee2cbe2b9991651922ee8a090e00b8742de8c9a6
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-bom/2.12.6
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.12.6/jackson-bom-2.12.6.pom
-  sha1: a9ca2fa9b490af3f5c294ad0a05151d8068430c7
+  sha256: 1361078ed8ae83eaa7e860d164389249ff3742ccdfef25ca33248dfd62e55342
 - type: file
   dest: .m2/repository/com/fasterxml/jackson/jackson-parent/2.12
   url: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.12/jackson-parent-2.12.pom
-  sha1: 7675e7641142bc3c583fc3bf2e30ec9cba076ad9
+  sha256: 62aa1c1679ade09f173dbf1b6c32d35c55e75800238fd5e48f13aa4337c0875b
 - type: file
   dest: .m2/repository/com/fasterxml/oss-parent/41
   url: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/41/oss-parent-41.pom
-  sha1: 2b66e40e928eb5f2f9c1c0da54e3c26f6310cbfa
+  sha256: af650fa4dd400bc5769320bcef08ed93813f349cabe8213d469acafbbd945d8a
 - type: file
   dest: .m2/repository/com/google/code/findbugs/jsr305/2.0.1
   url: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar
-  sha1: 516c03b21d50a644d538de0f0369c620989cd8f0
+  sha256: 1e7f53fa5b8b5c807e986ba335665da03f18d660802d8bf061823089d1bee468
 - type: file
   dest: .m2/repository/com/google/code/findbugs/jsr305/2.0.1
   url: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom
-  sha1: 95efa8cea662452bb74b34abe09a93ff47625c8f
+  sha256: 02c12c3c2ae12dd475219ff691c82a4d9ea21f44bc594a181295bf6d43dcfbb0
 - type: file
   dest: .m2/repository/com/google/collections/google-collections/1.0
   url: https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.jar
-  sha1: 9ffe71ac6dcab6bc03ea13f5c2e7b2804e69b357
+  sha256: 81b8d638af0083c4b877099d56aa0fee714485cd2ace1b6a09cab867cadb375d
 - type: file
   dest: .m2/repository/com/google/collections/google-collections/1.0
   url: https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.pom
-  sha1: 292197f3cb1ebc0dd03e20897e4250b265177286
+  sha256: 893d56afcea1b22f83220fd7e49a6668c5b8901e39bd59dc57b42f55673721ce
 - type: file
   dest: .m2/repository/com/google/google/1
   url: https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom
-  sha1: c35a5268151b7a1bbb77f7ee94a950f00e32db61
+  sha256: cd6db17a11a31ede794ccbd1df0e4d9750f640234731f21cff885a9997277e81
 - type: file
   dest: .m2/repository/commons-cli/commons-cli/1.0
   url: https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar
-  sha1: 6dac9733315224fc562f6268df58e92d65fd0137
+  sha256: 43f24850b7b7b7d79c5fa652418518fbdf427e602b1edabe6f11b85fb93eb013
 - type: file
   dest: .m2/repository/commons-cli/commons-cli/1.0
   url: https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.pom
-  sha1: bc51fd74ed7c8ccf75b3abc84b3613d6ba60eb89
+  sha256: 97ee40f4e80ca5ecc20162f4e97ee1adfeac1b45ba88b923d5a521e487c9c407
 - type: file
   dest: .m2/repository/commons-lang/commons-lang/2.1
   url: https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.jar
-  sha1: 4763ecc9d78781c915c07eb03e90572c7ff04205
+  sha256: 2ded7343dc8e57decd5e6302337139be020fdd885a2935925e8d575975e480b9
 - type: file
   dest: .m2/repository/commons-lang/commons-lang/2.1
   url: https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.pom
-  sha1: a34d992202615804c534953aba402de55d8ee47c
+  sha256: f1a709cd489f23498a0b6b3dfbfc0d21d4f15904791446dec7f8a58a7da5bd6a
 - type: file
   dest: .m2/repository/commons-logging/commons-logging-api/1.1
   url: https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar
-  sha1: 7d4cf5231d46c8524f9b9ed75bb2d1c69ab93322
+  sha256: 33a4dd47bb4764e4eb3692d86386d17a0d9827f4f4bb0f70121efab6bc03ba35
 - type: file
   dest: .m2/repository/commons-logging/commons-logging-api/1.1
   url: https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom
-  sha1: 825395875e4a7ac53277f5f746085a3e13a04248
+  sha256: 69b8be61aa746c7d02acb1b11eb3b57cb22b246780ed71d79764195cbbe3d99d
 - type: file
   dest: .m2/repository/doxia/doxia-sink-api/1.0-alpha-4
   url: https://repo.maven.apache.org/maven2/doxia/doxia-sink-api/1.0-alpha-4/doxia-sink-api-1.0-alpha-4.pom
-  sha1: 6ca82bb253b0a5f14bfd53d70f77ee87b1c66a9c
+  sha256: 1ac3583fa5308e7c7823e64f0975478bdf5fdd2031885cdfa6b2a24373224a1a
 - type: file
   dest: .m2/repository/javax/xml/bind/jaxb-api/2.2.11
   url: https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api/2.2.11/jaxb-api-2.2.11.jar
-  sha1: 32274d4244967ff43e7a5d967743d94ed3d2aea7
+  sha256: 273d82f8653b53ad9d00ce2b2febaef357e79a273560e796ff3fcfec765f8910
 - type: file
   dest: .m2/repository/javax/xml/bind/jaxb-api/2.2.11
   url: https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api/2.2.11/jaxb-api-2.2.11.pom
-  sha1: ad3ab62bfe2feea043b9be6f114d6296439fc6e2
+  sha256: 45afdb12df1830313353806f3d67c20afb03c7644e833cd5c874e5b525db088d
 - type: file
   dest: .m2/repository/junit/junit/3.8.1
   url: https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.jar
-  sha1: 99129f16442844f6a4a11ae22fbbee40b14d774f
+  sha256: b58e459509e190bed737f3592bc1950485322846cf10e78ded1d065153012d70
 - type: file
   dest: .m2/repository/junit/junit/3.8.1
   url: https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.pom
-  sha1: 16d74791c801c89b0071b1680ea0bc85c93417bb
+  sha256: e68f33343d832398f3c8aa78afcd808d56b7c1020de4d3ad8ce47909095ee904
 - type: file
   dest: .m2/repository/junit/junit/3.8.2
   url: https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar
-  sha1: 07e4cde26b53a9a0e3fe5b00d1dbbc7cc1d46060
+  sha256: ecdcc08183708ea3f7b0ddc96f19678a0db8af1fb397791d484aed63200558b0
 - type: file
   dest: .m2/repository/junit/junit/3.8.2
   url: https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.pom
-  sha1: c735a15ca8fc2ea77db963c71ade153ffeb8212e
+  sha256: aede67999f02ac851c2a2ae8cec58f9d801f826ba20994df23a1d9fbecc47f0f
 - type: file
   dest: .m2/repository/log4j/log4j/1.2.12
   url: https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.jar
-  sha1: 057b8740427ee6d7b0b60792751356cad17dc0d9
+  sha256: dc67378cf428c06408e7959e83bdc1518dd22ccd313e7c28a986612d65c276c7
 - type: file
   dest: .m2/repository/log4j/log4j/1.2.12
   url: https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.pom
-  sha1: 70545179454d298d1ff01335fbec3c2acfd381d5
+  sha256: cb54dedc5d8c4510148dfa792701cbac1a84c383a84f48f5a32e6d7e460bbb72
 - type: file
   dest: .m2/repository/net/java/jvnet-parent/4
   url: https://repo.maven.apache.org/maven2/net/java/jvnet-parent/4/jvnet-parent-4.pom
-  sha1: a80cde31667f91784a6c68a06b5c6a77418f7822
+  sha256: 471395735549495297c8ff939b9a32e08b91302020ff773586d27e497abb8fbb
 - type: file
   dest: .m2/repository/org/apache/apache/3
   url: https://repo.maven.apache.org/maven2/org/apache/apache/3/apache-3.pom
-  sha1: 1bc0010136a890e2fd38d901a0b7ecdf0e3f9871
+  sha256: 393c50afb4b7aa6eb57e5377a55a1a0610b19f75b52ece01308db04a1187a20e
 - type: file
   dest: .m2/repository/org/apache/apache/4
   url: https://repo.maven.apache.org/maven2/org/apache/apache/4/apache-4.pom
-  sha1: 602b647986c1d24301bc3d70e5923696bc7f1401
+  sha256: 9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194
 - type: file
   dest: .m2/repository/org/apache/apache/5
   url: https://repo.maven.apache.org/maven2/org/apache/apache/5/apache-5.pom
-  sha1: a99e211eb2be05af269c489b0f1abb9e8469fbca
+  sha256: 1933a6037439b389bda2feaccfc0113880fd8d88f7d240d2052b91108dd5ae89
 - type: file
   dest: .m2/repository/org/apache/apache/6
   url: https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom
-  sha1: 70e78921afc16d914e65611d18ab1b2d6cb20e57
+  sha256: 12edb5096e13f40c362d0bd40902589fa9586505123fa26799ce50b116fa5bb3
 - type: file
   dest: .m2/repository/org/apache/apache/9
   url: https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom
-  sha1: de55d73a30c7521f3d55e8141d360ffbdfd88caa
+  sha256: 4946e60a547c8eda69f3bc23c5b6f0dadcf8469ea49b1d1da7de34aecfcf18dd
 - type: file
   dest: .m2/repository/org/apache/apache/10
   url: https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom
-  sha1: 48296e511366fa13aad48c58d8e09721774abec6
+  sha256: 802feece72852dafcbd0a425a60367c72c5cb9b6ea5aae59481128569189daf9
 - type: file
   dest: .m2/repository/org/apache/apache/11
   url: https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom
-  sha1: cb35e3b8eb7f1adbdc91e015b60d0da3a4e16c4f
+  sha256: 9a4fb5addb41d8116b6441e9e3c48764d9cc562243d5608652bea6db0509297b
 - type: file
   dest: .m2/repository/org/apache/apache/13
   url: https://repo.maven.apache.org/maven2/org/apache/apache/13/apache-13.pom
-  sha1: 15aff1faaec4963617f07dbe8e603f0adabc3a12
+  sha256: ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d
 - type: file
   dest: .m2/repository/org/apache/apache/19
   url: https://repo.maven.apache.org/maven2/org/apache/apache/19/apache-19.pom
-  sha1: db8bb0231dcbda5011926dbaca1a7ce652fd5517
+  sha256: 91f7a33096ea69bac2cbaf6d01feb934cac002c48d8c8cfa9c240b40f1ec21df
 - type: file
   dest: .m2/repository/org/apache/commons/commons-collections4/4.3
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.3/commons-collections4-4.3.jar
-  sha1: 1c262f70f9b3c2351f1d13a9a9bd10d2ec7cfbc4
+  sha256: 62f8db7da73e551f82d70fd533834177af6bd953de4b5e85c44dc2100de4beb8
 - type: file
   dest: .m2/repository/org/apache/commons/commons-collections4/4.3
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/4.3/commons-collections4-4.3.pom
-  sha1: 10df23463e67877d44fdcf7c856c37d359a62091
+  sha256: 4f6654d48b92fb5ef780b75a83784777b5ef3b314cd7fcf9b52514a39b8e882a
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar
-  sha1: 905075e6c80f206bbe6cf1e809d2caa69f420c76
+  sha256: 131f0519a8e4602e47cf024bfd7e0834bcf5592a7207f9a2fdb711d4f5afc166
 - type: file
   dest: .m2/repository/org/apache/commons/commons-lang3/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.pom
-  sha1: 49405dd14bd8d02991d6b9e327206500852f7bfb
+  sha256: 043ab78d83f630af65c0c0e4289d584d5a816c82533814f3f7fac4b5509fded2
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/22
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/22/commons-parent-22.pom
-  sha1: 0e895fa7ed472b3b2081ef77e2d5ece78c139d54
+  sha256: fb8c5e55e30a7addb4ff210858a0e8d2494ed6757bbe19012da99d51586c3cbb
 - type: file
   dest: .m2/repository/org/apache/commons/commons-parent/47
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/47/commons-parent-47.pom
-  sha1: 391715f2f4f1b32604a201a2f4ea74a174e1f21c
+  sha256: 8a8ecb570553bf9f1ffae211a8d4ca9ee630c17afe59293368fba7bd9b42fcb7
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia/1.0-alpha-7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom
-  sha1: fff8727b6ff366d624669f4b8dc4d4c7316bbb0c
+  sha256: 172106a7ac51408883a074a1b847768e71c40fbbd969c8d645d2570026b811be
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar
-  sha1: 68464d54384c35119c70684d5d609b64635d1bbd
+  sha256: 37e66f15f348df957538f81f7e10a3fdcf84e5fbd687b2001ee3d6ab4a25aafe
 - type: file
   dest: .m2/repository/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom
-  sha1: d8e08f33563f684917311978da2ff03a9d0022ab
+  sha256: 3b0fa210dcbf0c92545ac31740fc2dd8af61dc72fd452cfca3d68aeabb642003
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0/maven-2.0.pom
-  sha1: 39ab6e95d88924b2ff950099a5ba7040b2280e84
+  sha256: 26f4354dd76180a0a397e7733cdcb5f7ff8744fd327390f989d8e3ecb4ddf2bb
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.0.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.2/maven-2.0.2.pom
-  sha1: 816e22beec3ee5c4a344959625a824bb6202daeb
+  sha256: 1eb80693b5d9c6d8c0124766606cca4e8199f7a07724d09fdf4e9c000ee8c304
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.4/maven-2.0.4.pom
-  sha1: a3b31a5c1d9b4ac8431896c84ed3d472938aa250
+  sha256: 39ed32405d60da7d1e194b3a13e53ead998558668db87d21bef7fe69d9cbd287
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.6/maven-2.0.6.pom
-  sha1: 1991be0ed3e1820e135201406d5acabf8c08d426
+  sha256: f5755c01058f048c61c3baf11e03c605b9c0ec1021ab40a3dcb76fb5bf51ff34
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.0.8
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.8/maven-2.0.8.pom
-  sha1: 0b6bdac7d11f0fc5c4c4bb0f336323f7b86cddc0
+  sha256: 33f59eb5269d810f999ce018f974e23ce4e8a144daf72943bd50265b6b7f4f0d
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.9/maven-2.0.9.pom
-  sha1: 696e3d1eaf254c63347613715faa31e5eecb282d
+  sha256: 6db25755b962d443bd7698b87654f336de43fd5319cbcc000e2e72c08c3619b4
 - type: file
   dest: .m2/repository/org/apache/maven/maven/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom
-  sha1: 7bc311044fbacb404de025b76feefa3567f0e5d7
+  sha256: d135cff96dcbbc8a5fab30180e557cae620373cf26941d4c738a88896a2d98ed
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.4/maven-archiver-2.4.jar
-  sha1: 5282cc3bc24f03eb33e13e6c4268e6f0190e38ed
+  sha256: a2d61a09bc82d13dc333e2e4c9795918364d0f959d40616dadeaf1add2575751
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.4/maven-archiver-2.4.pom
-  sha1: 79a8b8d7a458b25522f1339d35d6c548c6f97360
+  sha256: 2740f4988514c8a79e15af77b6dbb3527f3aae4cfe0a454c22a060cc70dee144
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/2.5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar
-  sha1: c999ae305f22ecfc5a000dca12a39b9491778bd5
+  sha256: 9fd34ed18dc5a49011380e620be86314f9f734193b8fcf85fb11e7b3a3929d6e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-archiver/2.5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom
-  sha1: a46a65782b96c7624c0ff64b50a91ba2935d84f6
+  sha256: 86214750be31034691143c797a2656bc647f0defeb4988031aa5afaf39f16a31
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0/maven-artifact-2.0.pom
-  sha1: 92cf1ca37284b0a7d88406ca32f9f6619948344e
+  sha256: ed4c936be78a46d73fb64a24f97f971465eb32e76c4625a9738b6f1a25b2d570
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.2/maven-artifact-2.0.2.pom
-  sha1: a8b0aa4f932e948f979c872326a5ac9d7f4e123c
+  sha256: 0123d59dd14fa00b8a50eb299bf59945dbd824b6deec43823e2612151ca38c17
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.4/maven-artifact-2.0.4.jar
-  sha1: 9a5beba90747559ae5327b4edadfa89e6a5bde24
+  sha256: 7294778dc3eb8ede4950ccca80dab8debc725304116b19ccb1929023d12534c4
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.4/maven-artifact-2.0.4.pom
-  sha1: f11d6b6653cf6c4d8b82144268667680b3a12177
+  sha256: d8e78bc70afb9631d4e7c9db8f52778c4fd8c7c7998143bd7c420c40cf63ded4
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar
-  sha1: fcbf6e26a6d26ecaa25c199b6f16bf168b2f28dc
+  sha256: f45629a70af0dfec1c1b542e162a2aceb976bb492825b6ee192e6a14fff238b6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom
-  sha1: 973c14299a051daf4e767cc60f15788b50c887f2
+  sha256: 7231047667b34a36cfed19d51ef38c9755e97e1acf11595a4b503c5ce7f0c595
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.8
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.8/maven-artifact-2.0.8.pom
-  sha1: 351f42403e36c8661e8f0a8489bf537ba31ab17a
+  sha256: eb7bf61f1215585e1d625781a803d9e7fe4ac21466b150674873ffa4819809c7
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar
-  sha1: 66f0c8baa789fffdf54924cf395b26bbc2130435
+  sha256: 0b16842a33350f5478c4c717bf664251c27459ec5c0b8d0ca4d0050545aba48b
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom
-  sha1: ffc6bb3eabd75a28d704e0431e7a44e7b4dff9bd
+  sha256: 77f614225a71c207a45f270be0190d34bac4dbc14684cda26015717710411aee
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom
-  sha1: e37430ef3c3ee1d33817fdb45a0e538f49932c0a
+  sha256: f658a628efd6e0efe416b977638ba144af660fe6413f3637a4d03feb6a1ce806
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0/maven-artifact-manager-2.0.pom
-  sha1: 83294af9cf17a6779bbc585079ff6e9920297d37
+  sha256: fbe4dae4a41127b78f75a40543d2aad51130252d904f5bdab34aeb1f08dbedd6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.jar
-  sha1: 982eee8d0feb92587beb60874c731febc6d9ed9d
+  sha256: 3ceec8c66c1d206d6e51e43659bccd26b53db32ace638b5f77f99c43f9a51e3d
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.pom
-  sha1: 157c24fb3ec09b9a693f88dc571fc17ed0669cca
+  sha256: 94348507ad85d221df9167e9db313dfdb474d59e715d2c0638d3eac341756222
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.4/maven-artifact-manager-2.0.4.pom
-  sha1: d9292464a88c195fc9457066fc17e0ac2509d0dd
+  sha256: 5620e8f30457d1f379bb3dc0f67e759d890177befdf5f2591809f9e0e302b68a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar
-  sha1: dc326c3a989c10618e09a7b77cadeff297591942
+  sha256: 2cc0e74f4f8fe9f9733cd207101809273026464c64d3f1fb2af06b9d2a3c323e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom
-  sha1: 8cb8b1dc4d9f7fbd90be4e9c8e9a1d353e28666c
+  sha256: a80884dfac999ebdda57904f929a14f28ab08e5411d515bdb1fbdaacf0ed6d6f
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar
-  sha1: 53224a5254101fb9b6d561d5a53c6d0817036d94
+  sha256: d913865e03e719ac5733260019e98090a12b50683134e65f78c36e8d67f11ff1
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom
-  sha1: 84c14dcd1d85eebccbba665f95057b5748f51d83
+  sha256: d573bbb1b78c76523c45aba2859d390883b932dfde67e3c2032fc443c0fa098d
 - type: file
   dest: .m2/repository/org/apache/maven/maven-artifact-manager/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom
-  sha1: 062f05a1fc0a40a6ea8fc8f0a1e9e2c02057ebaf
+  sha256: ecf58351f8fe0c398b8b452216705bece5291b9b327d30202c16b28ac680450c
 - type: file
   dest: .m2/repository/org/apache/maven/maven-core/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0/maven-core-2.0.pom
-  sha1: c696da34f8a5d1af3a9b7a7d9da2e2d3faca8119
+  sha256: 7736a088c18a6d189741d0c80b4ca73b302781049fe216d6edbc4ccbadc2543d
 - type: file
   dest: .m2/repository/org/apache/maven/maven-core/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar
-  sha1: 33b78ed70029bfca9fadee5c8e7c9b27b9a39443
+  sha256: 710d56c05add33beadea2f86254223955aca570c15a610f81be07c96c919d7b6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-core/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom
-  sha1: b02365ee1822cff5839d9f85bc9b1cbfab9f5674
+  sha256: 1ab7fdd1b82382690c081d3ea3f53bad2902e1d62a11a8096488711e7a5f607e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-core/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar
-  sha1: e1003a0a66dae77515259c5e591ea1cfd73c2859
+  sha256: da9bdd720f0b1861fe649a2edf8fc0a65e4e2c4a1a05d8d96adbfaa1319f7285
 - type: file
   dest: .m2/repository/org/apache/maven/maven-core/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom
-  sha1: 25da75e747afa1c361f003aed72de2e48dd190a7
+  sha256: 1ae908507b9781902c425f261af8aa1bf5cf77632a69534aee479887787ee059
 - type: file
   dest: .m2/repository/org/apache/maven/maven-core/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom
-  sha1: c7312a507d519047be160bab5cbb56c07d0247a1
+  sha256: 5cc81603cab47bf20dbfd5e28e311da1fd26f2e3617b50547da5cd0b4f59edf3
 - type: file
   dest: .m2/repository/org/apache/maven/maven-error-diagnostics/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0/maven-error-diagnostics-2.0.pom
-  sha1: c56a37e3ace52650a9a8c811a9f1247adb6d5bd9
+  sha256: e4af173db164e0d7cfc5f1d38dfb9d8323d2339d25246fd87816da93168af81d
 - type: file
   dest: .m2/repository/org/apache/maven/maven-error-diagnostics/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar
-  sha1: 49f5380c07a79cd91ee09e0cb9063764f1f6525c
+  sha256: 59c637b910c0de53d28aeeb6444ee5fe1a8fa8f3da32dbbc4485250c166d3fee
 - type: file
   dest: .m2/repository/org/apache/maven/maven-error-diagnostics/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom
-  sha1: 31c0ce961dfc5b491e92ad0804dd48840dac7796
+  sha256: cb80662bd8274131bb09e140a4075bff660bdab5be56bf0f926efee0389f3c4e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-error-diagnostics/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar
-  sha1: 46cc6b69beebc7bbf59c4f3842f72f2c1942e8e5
+  sha256: c16be9fd50777338fa36d09c5c037b2d9ef9b68f00c67e9aa54b2d2b19fbf8f2
 - type: file
   dest: .m2/repository/org/apache/maven/maven-error-diagnostics/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom
-  sha1: dd562ddf84fc56b0693b42184a27d86d126ef02b
+  sha256: 581cf29ef72ebbaeff78a8054482ea8a4cd43e6d905f4adb7a16edf1636a619b
 - type: file
   dest: .m2/repository/org/apache/maven/maven-error-diagnostics/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom
-  sha1: 5074991d8d14a88e7c8bff294639a254d7ef387a
+  sha256: 228367b7569fb1462a3eb1423bc2778e2fc7fbaee3d3767890c02b8924fa1889
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0/maven-model-2.0.pom
-  sha1: a02c0796d872bc1b8c0cd248b5ede0da32a356d0
+  sha256: 2d727af4b8bd10382777d34a16e521e948b8a9684f1094bf06ee9b5b616bd5ed
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.4/maven-model-2.0.4.jar
-  sha1: f5f01bfd082ca5bb027c07a731c43c1fb791756c
+  sha256: 025e9ba00b87e33c90ccb9f8befec4c3c6baa42436f158f00a69747007f84351
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.4/maven-model-2.0.4.pom
-  sha1: d67e6602bf431c8c7a7bce1b7c989226cbe9d405
+  sha256: a0df5fc56a44d4a716291d8879737a80516db598ca9c823f1dad525149df82b0
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar
-  sha1: 9649253c0e68a453f388e0a308c0653309f87807
+  sha256: b86dbf20852da19fb17301ae7e2a40d87930c7d76fe43f0f93ff86b8a64c6962
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom
-  sha1: ea1dd9b8c7b1c3d2f0bdf314390ed7da7e463460
+  sha256: e88566fd64906e8e9a2315e5cb67efb7e0f4947a1c45a45cff399f64a235ac1f
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar
-  sha1: 9fb844625928dd992842e180853fbb2b197c9a9d
+  sha256: 87083dd97721542f2745eede587fbb6cb1aef2b395f46c2bd578c6d9d7b63521
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom
-  sha1: 0978fe1857f847436fd3c454d25161e26fb2d5ec
+  sha256: 2bfc8ce93b46c1bbe8e809197a2f970c5573d2b0d3412c84d7cdfa5961299087
 - type: file
   dest: .m2/repository/org/apache/maven/maven-model/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom
-  sha1: 548a7e6354c1bc4a49dbec6bd17b4f8e9310201b
+  sha256: 62dd8e35a2c4432bb22f8250bbfe08639635599b4064d5d747bd24cf3c02fac5
 - type: file
   dest: .m2/repository/org/apache/maven/maven-monitor/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0/maven-monitor-2.0.pom
-  sha1: 7140f92ccb9931f14b540f34dbc84c35fc33cf91
+  sha256: bfa63866f2312b1fe99689520d4098824833fd18c548a315901be3b31d5c6122
 - type: file
   dest: .m2/repository/org/apache/maven/maven-monitor/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar
-  sha1: ab682e67281bb025980181c83acbcad19042a342
+  sha256: 47289bc307849383d41eddbe3800f1945b2204ab319b0d38e391f6780c37b4e3
 - type: file
   dest: .m2/repository/org/apache/maven/maven-monitor/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom
-  sha1: 7ed6529eefa74ca263b65a7c20adf65af5bacdff
+  sha256: 2cfd187d6465c5ad99552da8441d31ff0c1ced1808d2f624dbdb49223d3baa89
 - type: file
   dest: .m2/repository/org/apache/maven/maven-monitor/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar
-  sha1: ae55264ab9ffbbfdba08c8c7853bbe4a2dd32e8a
+  sha256: 69f5fbf13f7e54885b53b5c2c00adb24178e43a6e997c6350a45a7dc287ebd2f
 - type: file
   dest: .m2/repository/org/apache/maven/maven-monitor/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom
-  sha1: 872e92b9f9ebed4761ea469c2c385f2ffcd6a589
+  sha256: 4fe978f252f57c1768d917603127db3b82e98820059b4943ae04b79c5ac79419
 - type: file
   dest: .m2/repository/org/apache/maven/maven-monitor/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom
-  sha1: 421fcf473a51d9695d8dfe4f8e977ae38087f2ae
+  sha256: bc962d48dcebb463c1071004015c4609516d616e884ce36eb7390f9a8095a65b
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/4/maven-parent-4.pom
-  sha1: 0fc039b0bd4d17d7c147a30e1d83994629c5297c
+  sha256: 2b4fe0b8d8b098514fae7bc73891864abc1da4a530613f836f298fa9640d7b63
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/5/maven-parent-5.pom
-  sha1: 5c1ab38decaca1ccd08294aeab135047ebbae00d
+  sha256: 5d7c2a229173155823c45380332f221bf0d27e52c9db76e9217940306765bd50
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/6/maven-parent-6.pom
-  sha1: e9c3dcf052c26ac7340fbd7a03a751e482855330
+  sha256: df8f5fc5e956249833fe9e9bd6df891ca7224ceff1cb729dd84848376545afda
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/7/maven-parent-7.pom
-  sha1: 2426103263cbaf5519433f16bd98cdc31870a10a
+  sha256: 54adf65728e30283650f9a9fac0d2d33f60f2c99fbcdea27671e6f6b076f6df3
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/8
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/8/maven-parent-8.pom
-  sha1: 6f92a85ec401422bfc6572759a0bab2ff5df525e
+  sha256: 3cb6712f827c80dc6b0b0b967776dba451c023a92b7741bba45d23ab7a83281a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/9/maven-parent-9.pom
-  sha1: a7d098bde368f683c2b51475a903a1e74b61ba32
+  sha256: 8e7054879496abff4f6960b946dbf67ab33671bf8c9b98bc154b7e0fb8bad5ae
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/11
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/11/maven-parent-11.pom
-  sha1: 4bb80173fa4979737840fda012af86f5beabf1bc
+  sha256: 7450c3330cf06c254db9f0dc5ef49eac15502311cf19e0208ba473076ee043d6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/13
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/13/maven-parent-13.pom
-  sha1: 743843d9973c083b7755e4a26a9c2ac369608ab5
+  sha256: 72d02bac812c6f1e83bb69801b163ac61aa2069b0cceedd90adbab8038deaada
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/15
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/15/maven-parent-15.pom
-  sha1: 63d5a76e7f9d3c6d7870bde13438856ef5300336
+  sha256: e25770d5d46dcdfdbb9e38ca04f272c5bdf476d88392ab4044ba90678e616d54
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/21
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom
-  sha1: 0ecebf1043d9c7bdd3d32a4184ad4ef9ad3ea744
+  sha256: fc45af8911ea307d1b57564eef1f78b69801e9c11a5619e7eb58d5d00ae9db8e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/22
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom
-  sha1: b8b69066f9f1c388a977669871df9b66782f751a
+  sha256: 165a409718070698b4eb18fdfee4325bc3361cbb8e96a35f4669982cd2adb79a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-parent/23
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/23/maven-parent-23.pom
-  sha1: f92ae4baba6616609a29f6287626ee3f50ed7d6e
+  sha256: 5425501edd9e0bd7b01eca53cc92e06836d24851151304f9c6759e1713541685
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0/maven-plugin-api-2.0.pom
-  sha1: 4712e15fddee58ed471b2758facce36030e21b83
+  sha256: 701487785d69eeb27ff700a2d7d1af708c5e4b66cd640095193c07fefaff92e7
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.4/maven-plugin-api-2.0.4.jar
-  sha1: 41cf00efbedaedb8214f4dd4425cb92f035d0192
+  sha256: 9ceee514d1ea380f2ebd146a55c6b504025b91411d53e0248391cbc84397da5a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.4/maven-plugin-api-2.0.4.pom
-  sha1: ddebe6554f9fd3c7d1064a122a57bd13a71efa48
+  sha256: 86eee056eb9e468bc78febc4dd2f6b69584e18f4670f7615f4b67e094dac662a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar
-  sha1: 52b32fd980c8ead7a3858d057330bda1ace72d9d
+  sha256: a1b54bbe38d25ccd3179c5563156b3b0c0ecd014647c3ebaeba8e92b2e2e5053
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom
-  sha1: 3af72b052dfefb73ecfae742613012b5396c8863
+  sha256: e5886cbf7478ed0a89d4502cb4b6b4d25095a53b74e07439ec0ab3f793405822
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar
-  sha1: 8b8cae9daa688fdb57995c6835a3e24475d554c0
+  sha256: f1e4b0af3079cc0db361eab9429a3cda7b118cd032211c7e61b3805a62bfde1f
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom
-  sha1: 4f6c3d5d50d1e22dea74629b3c52e22b30b6cbbd
+  sha256: 0ef1a886c795b5ca48d08245b13d1128ecbc6fd0f05e6556749547df9978680b
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom
-  sha1: 29a30b7c8180601523293fd61b00fcb298d32230
+  sha256: c10d0460c2d5c5076304598965991d6257d1bf31bdef921a17ce3d059bce654e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-descriptor/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0/maven-plugin-descriptor-2.0.pom
-  sha1: 7359de4f4f48a32e36b7b61c94cbf550a4694c1a
+  sha256: c5122a68fe16b32009f55e1d3434941393cb7787a1d39e55caa481f6a9fd80ff
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar
-  sha1: 30a00f4ef12d3901c4f842de99e9363e3743245f
+  sha256: e6e99e03921e576358e24a797e3034d0587ad08dac8ebf78b3fcf3e1a96a37d9
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom
-  sha1: c03fb59f559651730a98907d4acf65e6ffb886d6
+  sha256: 77ca407ccc76079a2b60f4d3e652c19552890303fa00748623e372eac09039a1
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar
-  sha1: 10443d038cd57feb4a027e7dfe09bed0925a1953
+  sha256: d4b0d72958125b6cedc12c7ed5c50a20624e1e57ee37d622fb67f30dcf0327b3
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-descriptor/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom
-  sha1: 2752f80f21bd62796600c66859406a08a587c2d9
+  sha256: aa38ab11a2c97f9b61dec56074d59e98f2ea63c0cd7b3b2f61acff6549d064e6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-descriptor/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom
-  sha1: 020c06240db8c2f9bcf8450414ef040becef16e0
+  sha256: d4ef608f90dc9599c0cc325ca2ccc2e1ceb439b3d2ff31ae22e30ac1a63a68f0
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0/maven-plugin-parameter-documenter-2.0.pom
-  sha1: b6a1ae66a56dfea8531348ed6ed00b2892167a09
+  sha256: dd73b6a91523cf25ada769922b368e1f4a0f1bcd41ca9aefe9d98509f4d213bc
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar
-  sha1: df6fa6c4adb313cb8937ffae96368bec1fd5d13d
+  sha256: b5f0dd177264a6e25ce0ed8724f8b6f3bca48b215b9ff4576e1bec7b0773f9e8
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom
-  sha1: c6403fbdb781a3d47a771656054defe1173ce486
+  sha256: b5b53025b13fa0013ae2caede21f9af4215c25279db4ee0a1f943aaa8815c174
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar
-  sha1: f481e2677384f6a0ab96633567d736e70657e042
+  sha256: 3be9db19335747e8a22f768fab3539992a66d280ccff5f8cd487cada733aee98
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom
-  sha1: a575e74bbf8402a2371034d3a128d214c4cee060
+  sha256: 3d356e97c1ab8c5673e8908b07e1e50d842dab8cbea8a2082f87016b891f91a6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-parameter-documenter/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom
-  sha1: 8eb54f97405512e83f680f29ef6163f5ef082acb
+  sha256: 902b0160f7b81ec76452468f8ae087fc1cfefc08367c84d9197512dfb01d845d
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-registry/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0/maven-plugin-registry-2.0.pom
-  sha1: df5235f26d58fbeb0c41759e19dba31d4885e77e
+  sha256: aa0ff0841c724a7abdf25bd39a5d518de4ad7b688496137cadec0f58267e2d85
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-registry/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar
-  sha1: 4242ec8629b4797387751379f57e72cb718aac7a
+  sha256: 98d6f3fbd17a67736d65e9c4ee484c5d6bc54589042e7cd3db65f87d91070f2a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-registry/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom
-  sha1: 2e13beea3b3511c6075c60384d9e7fad18efbcdf
+  sha256: cf633e8cde33e65580776d845756d332d24f7c6d5bf9ae90fc6c43d73cb5fe23
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-registry/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar
-  sha1: a7172a87a7cb901cf6df4df9fd89a3c2d3f8a770
+  sha256: 5e6cc5d0501c8d9b9abf9605283e95733b9428c9033a079502cd4d97cd0c490e
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-registry/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom
-  sha1: 403ed44092f56e1ebab891f37c69d61936c5c4da
+  sha256: 7de23d8212885031dc2e6fabc327957ff8324563a8fbeb10b0a85b498b826667
 - type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-registry/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom
-  sha1: c3575ac9ad32638af33d88829453bdc902ea8711
+  sha256: 3db15325cd620c0e54c3d88b6b7ec1bac43db376e18c9bf56bd0c05402ee6be8
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0/maven-profile-2.0.pom
-  sha1: b1c9a2e447068d9ac0d7834afcf3f962d24aebff
+  sha256: 2a8a1b9046b8f26c2dd5fa4d0c5b18b55156f7d1291f2b64dc31b1261018774a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.4/maven-profile-2.0.4.jar
-  sha1: a19c37fcf520a220801cc31d70520ad874f3ba44
+  sha256: 8e75daa4cc3f8a2aa68de0f8a28eaa655fdbb2e04708bad19d63657045ab7f14
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.4/maven-profile-2.0.4.pom
-  sha1: 581a2f5aecc9d6130bf2c265b1787dd9ab688be4
+  sha256: 3dfe0725e12871248ac59c36abe1316fcfeab2051bd203ba53edfdd0e658ca33
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar
-  sha1: f03cd3820d2b4d60b93ccd17a1c14e8eeef63f79
+  sha256: 89c07a73ea3b41e6c3c7e126871c898f1741fbfddd35633f9524fda09c25dc01
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom
-  sha1: 12d0d8217e613b9cb487c1d1d0db744a4f588528
+  sha256: 09455abf6ab86671fab0ae5bba8293c17382c8a9c53fafc3befb3e0720f2b707
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar
-  sha1: 0b9b02df9134bff9edb4f4e1624243d005895234
+  sha256: 88fe952eaf4e28da0533ceef5d8e9b7fc9f09f7f825ab342130bf4b8c3805664
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom
-  sha1: 616ca5d9ab345e415c6e3f5f75ea24a952690ac0
+  sha256: 3be51b8a7e080ae0a765e870fa8c3acaab2a916ec24cbf0bb468d5d8abcbc104
 - type: file
   dest: .m2/repository/org/apache/maven/maven-profile/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom
-  sha1: 075b47a5262cae02c228137399b8247e50a43284
+  sha256: d125b3ade9f694ae60ef835f5ae000b6ba35fba8c34bafd8b40a1961375e63fa
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0/maven-project-2.0.pom
-  sha1: 296a476d8e125fc1d7621c24320d7fedc0019ff1
+  sha256: dd14ed05a563983fc4496224dca9562c683aa68f70a9d279082d6fb5bd8232d8
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.4/maven-project-2.0.4.jar
-  sha1: 14fc171d32ad58451686730d8be3a7a70c6e2b83
+  sha256: 27a6b287359f57c02a263369034b0c16a597c7f7b99df45e8f9b1c57a48c52a6
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.4/maven-project-2.0.4.pom
-  sha1: a904c3b53bc6c82d928cc97ad2697bc5798b3f7d
+  sha256: 8dfa987422e1eeaa2f8da8d2696f9bc00c127647830e56254ffe6ae5709faeaf
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar
-  sha1: c0df764cd8f5bac660bfa53fa97fdd53663ee308
+  sha256: f091ef5587537947a4c6e43cf200c567e1bf44c101443e8f8cf51e2c126e0195
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom
-  sha1: 28e9f98ae3688d8831052283b2d65bd18295a7f5
+  sha256: 7dd6468c154d99c39a94c7a8c734aa96366864334b6b2ea10778459860cbe3e5
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar
-  sha1: 30ec37813df5a212888a1f3df0b27497ecef4ad8
+  sha256: c82db125f53716f59008e3214063869717a976bf857879de6d4092c73cdc7e12
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom
-  sha1: 152cb93838c431848f31cd5a7a7a11b98c57135e
+  sha256: fa8043afdbe232e7541b965386dc582be336783ac220aadc9bde401b02295a90
 - type: file
   dest: .m2/repository/org/apache/maven/maven-project/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom
-  sha1: d96e4545b4700ac177430b5189c3f2aa54f62ca1
+  sha256: 34af0baedaef19375b7c1a7da967e9089d5e0754647fdbe9a302590392874b77
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0/maven-repository-metadata-2.0.pom
-  sha1: c8f40fad92bb0e75465e4cf800021264f3024bfa
+  sha256: 28af1b6839e3f6709d47f5f17b3574c571d48e6f69d3fa385bd5d9bc0e721ff1
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.jar
-  sha1: 052137067d985da5e1cb5d8b46deea88e1c1f060
+  sha256: d033d8cb402ded41b2716b67fad71ed22b2fa6fa4a35fc709e6fb079752eb2e9
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.pom
-  sha1: f731304626897c68836461f0df5134f26aeddcf1
+  sha256: 4dd5ff83a2089613e828ee6c8bd6888d8732217392e2c442f6302df4a025e629
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.4/maven-repository-metadata-2.0.4.pom
-  sha1: 0d3c36fad639666bcb5ad1d2de6e3d4c275625cb
+  sha256: 2d5e793791748e714becdbcfe29b73f512f9e9f87715982ff10f4e77eb01837a
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar
-  sha1: ae64379396d2eba33616ce1e0a458c3a744b317b
+  sha256: dce817d7c4229d5e666247c05853ef8ad7ac1b72d27953501c4a1ea739f67b25
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom
-  sha1: bdcd11054562df6124286aaf252ae8f256879e26
+  sha256: df10657745e39010954fd009276b65b75198bdc40d0adb9916f9697c71fcd986
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar
-  sha1: dd79022a827b1d577865d5c97f8ad0c7d6b067b7
+  sha256: 2c302f060de887716be438e0eb0c3d89d7ece213631882446ee0b19880c00dbd
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom
-  sha1: dc5dac36e8c773d8645a681b71b3d80a3e3b8916
+  sha256: 0447b3919bc7d0301b763852aca8dc0e87ccfbe34a4d5257f7f4fae8a4e87998
 - type: file
   dest: .m2/repository/org/apache/maven/maven-repository-metadata/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom
-  sha1: 415f88d96ea04b0fcef38c50123da1ccc2be49d2
+  sha256: 9dad0f56523955b60a9903f4e8342891355d7a59c77f36a3b53cf6ff2e4df625
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0/maven-settings-2.0.pom
-  sha1: 76982480c0e25f8ba8e9af7c2d3e743f649553bc
+  sha256: cbff616828f8a694e59c4d5efe1198d4bd6c9bc1c03496dc5c92083a9419b4ec
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.0.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.4/maven-settings-2.0.4.pom
-  sha1: a7d89a40edc6ec304ab0434c237c4d7797d95b95
+  sha256: 9469dbe562fcf278a4a31d6050629790c1158bab3cd39b5ce8f6fb4ccdd13deb
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar
-  sha1: 5da16cf9def50e3a352cd7e8923a49ebd72003b8
+  sha256: bb7af11f28a37d21bf20e11705c78aa4adce3aaff1b9b981c031c6be1aa0ec97
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom
-  sha1: 6e8ca6b7fce58a28d2b73774fe277593af14d82a
+  sha256: eececa44387deebbac73192967eabad80f2f43fe96f70b98f3e21951b1bfaea1
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar
-  sha1: ab8d338c00fab0db29af358ab0676c3c02d7329f
+  sha256: 1e5c98ebc4b9ae1f2c8d843c1dd9701a1c25b9afaff143c3e1fa4d90c22850fe
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom
-  sha1: f1fde243f26152cc66f7f1d6b4e3bb19d39d6847
+  sha256: 672f22f9b697784518b8b84719324013a8f1bf0337f1d3059b83982d4ca480ca
 - type: file
   dest: .m2/repository/org/apache/maven/maven-settings/2.2.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom
-  sha1: d54135b84370b3b0b70d84ffbb4ddf161c303d56
+  sha256: 0d25a88a1b1e44801f8912206a40ff249cb5702ee87cf3d243d5213f7bcf534f
 - type: file
   dest: .m2/repository/org/apache/maven/maven-toolchain/1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar
-  sha1: 1ff4a3f5869f68dfa05562a84e7a5d510d909608
+  sha256: 95730d85b872517036b12ef7d474e72f2467f09ae40006169570450e6de6ac95
 - type: file
   dest: .m2/repository/org/apache/maven/maven-toolchain/1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom
-  sha1: 071d6b30688d3ca1036333069b33811361b37cb1
+  sha256: 665a0be425b12cc6938a41f7ebde2c4c7c23b02b3826344462001057449d503d
 - type: file
   dest: .m2/repository/org/apache/maven/maven-toolchain/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.jar
-  sha1: db9f7eb8b6708b7ee46db0f0357fed43ef555793
+  sha256: dcbddf7cbc3bb03f76afdeb598491ae815620c5ff66cf8f18d7239d1dc764dc8
 - type: file
   dest: .m2/repository/org/apache/maven/maven-toolchain/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.pom
-  sha1: d2cd1efecdec107c59eff53ac1510f2fc145956f
+  sha256: 7fca590bc5f4b4841c3a00dade5fb9e1f454f178e45e5e4165304e7ce1be35dc
 - type: file
   dest: .m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.jar
-  sha1: 154f4f29ce3c977061e0943a47ed6b1e6b70347c
+  sha256: 8de51faf9303a49a479e8fd01608166a035f16d259086c84f62afdae2c18617b
 - type: file
   dest: .m2/repository/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.pom
-  sha1: 35df63bc7e279c775f916724b47b61b7531775f7
+  sha256: e48a5204cfacc45a0885ff5ca0a6e78001d472e21ec1d7255e3210b53f0ee1a5
 - type: file
   dest: .m2/repository/org/apache/maven/plugin-tools/maven-plugin-tools/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-tools/3.1/maven-plugin-tools-3.1.pom
-  sha1: 7d23480ccfabb33ee39bbbe01de69c38540e39b3
+  sha256: ea3422417c914115799d62be376bcf8f79f05b896905f84e9da55af5af66abec
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5/maven-assembly-plugin-2.2-beta-5.jar
-  sha1: b1fd2e4dea47cb9c2858d26ad0aa608b802d34e2
+  sha256: b5ec1a1556b3cf90e248fd58a6d96b5b0e7250da3c38cde7dca8f050dee976bb
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/2.2-beta-5/maven-assembly-plugin-2.2-beta-5.pom
-  sha1: e7faf80b1d8086bd26dc2c67f4e0252b8d47df44
+  sha256: d1e70b2862b18af99e026eb383675cf0b4ade5b2d8b337c2bca0b2abb7e95b94
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-clean-plugin/2.5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.jar
-  sha1: 75653decaefa85ca8114ff3a4f869bb2ee6d605d
+  sha256: c22932343626116030dffe05afdec0060cb297e6ac78b96f195ecbf2bd47af73
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-clean-plugin/2.5
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.pom
-  sha1: 8571a1cd21bed4fe28656c3303526fa7d1e582ad
+  sha256: c88e2300d4828feace25b8ff391bd8b251f4f3a7fe333a6ea2a55896196925f8
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-compiler-plugin/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.jar
-  sha1: 9977a8d04e75609cf01badc4eb6a9c7198c4c5ea
+  sha256: 62286cd88a4bfa04e31c52415a61c4cc5611b7e814fbc96be6f217d5d3c302c6
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-compiler-plugin/3.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom
-  sha1: 5fa5457d1460c3af6a72521226d71cd9c1f395d8
+  sha256: 45940a032f78466dd1686acb5769eca3ecc9baf7ca9a3517c138887d8cbe8b1c
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar
-  sha1: e3200bcf357b5c5e26df072d27df160546bb079a
+  sha256: 1f22f2e528daddbc5d06518c4dbe4d5f4fa6995c8441c702ee5d7d506bb4b4f3
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-jar-plugin/2.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom
-  sha1: ae9d54d974e163f260f89ecea8ff6d55e4b0963e
+  sha256: a98f60925af4a1729529a1e9c5aba78ffdd024c67a8f825ed974a0ab006d315a
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/16
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/16/maven-plugins-16.pom
-  sha1: b5c0ca0bf4e73800f888cee77741bc1fa9c8ed78
+  sha256: fcc5d05bda9c1ed30e48a3a86409f46ad1c727a8a00361485c609f99bf95db47
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/22
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom
-  sha1: beff44ae4eff1e5c79c01972083cd11fa6982462
+  sha256: 34d303bbdd31d34f5a1570549b0e134b72afb18db53d8fcfdad222d51e941630
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/23
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom
-  sha1: d40d68ba1f88d8e9b0040f175a6ff41928abd5e7
+  sha256: e07710c7d516a873c8fcafe85840d8a1a78f460c9a364d1c57b1d9e4554639ce
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-plugins/24
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom
-  sha1: 91e68408f2d1774c5f39c0c4cd56a8b83e47c67f
+  sha256: bfba38bd72d1a898f6f88e17cea240c67426be64d00c166b29c461d9bc149e56
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-resources-plugin/2.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar
-  sha1: dd093ff6a4b680eae7ae83b5ab04310249fc6590
+  sha256: 07bd1b98b5b029af91fabcf99a9b3463b9dc09b993f28c2ee0ccc98265888ca6
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-resources-plugin/2.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom
-  sha1: 5db5c3a879f31e8de7b580c79a52b245454c4620
+  sha256: a7842d002fbc7d2a84217106be909bc85ea35aa47031e410ab8afbb3b3364e2d
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.jar
-  sha1: 2b435f7f77777d2e62354fdc690da3f1dc47a26b
+  sha256: da14e7c9643cd3991355730455324a46ac83d633da6446cde96ef8356afa42f4
 - type: file
   dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.pom
-  sha1: acfd3ed5fa8d38e8fceb48b06d3363712a91028f
+  sha256: 91e7b0ac3866d8932cf12a5c676223f48b1c4a4c65b9a73e150cae96418abfbc
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0/maven-reporting-2.0.pom
-  sha1: 629c69205b4c6c516f8a853fe8e1ab2e697df8ba
+  sha256: cacd1da4ae4eb15bc4ddb581ceda9d097b275506d7731d03458edbcf737024d2
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom
-  sha1: 0257fe61312283ef58817edf197e9c90db0bba25
+  sha256: ab803be997ac806ee7f2e179ad3cda640345ed8fc911082b1f80202c7fc463a4
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.9/maven-reporting-2.0.9.pom
-  sha1: 92fc48457601be497488cc316bc3617326977a24
+  sha256: 168340af95f5ba50362c015d88d8dc7ef5737456d65484df8c3a2f4631ea5789
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0/maven-reporting-api-2.0.pom
-  sha1: 6c503051f089ab7bb3c93b0ff8b528d32e1869f8
+  sha256: 2b013803feb37705908b5af78fbcf584e479f03d792964dc96446dceed0d1756
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar
-  sha1: 29ec352c90968c345b628be6c40ddfb5ec7010a8
+  sha256: ba372ac9e52b481671bb3ea913063cd66747780de340d0c3b1f18c49ec998786
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom
-  sha1: 8d8037467cc092dbaf1ca8b513172e2a893b5b9b
+  sha256: 4ac659858bac5929ea8fc183d7ce4b588d7e69363a76277f6a26349393686657
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar
-  sha1: 88c2303c3d1f54472cbd39cac11d9a4ad0afca25
+  sha256: b43cd126a7dde90857cb9ad6a46ce65787a6597fec729b509a074e6d087e893a
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.9
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.pom
-  sha1: bc210876e266e2f3153e96832cbdc5cd3ba53cba
+  sha256: e50e96c88041e2236420e5483b407175c07f401b0d49f0744fa48de2d372448d
 - type: file
   dest: .m2/repository/org/apache/maven/shared/file-management/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/1.1/file-management-1.1.jar
-  sha1: 1a751b5b40520478458f31dca58d763c34580755
+  sha256: b7d139b2a04687d399fb296a1d6c1d7925b54a65c2ace87b1cd4ea20e3d422c1
 - type: file
   dest: .m2/repository/org/apache/maven/shared/file-management/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/1.1/file-management-1.1.pom
-  sha1: 9fb292b31e122269798f412b6210233e0fb9316a
+  sha256: f7f68cb1f1dd99706fd30f2d40daad485dd160528408be6642875851714a1686
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.0-alpha-1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.0-alpha-1/maven-common-artifact-filters-1.0-alpha-1.pom
-  sha1: 56e58595dbc210d8b4d367e025f368003f802891
+  sha256: 96edee15f85d167e596a1b251de23b6359116da73aab500851c20d8bbfb738bc
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.1/maven-common-artifact-filters-1.1.jar
-  sha1: 9a7f3625b33546baef4de817aa334f22509f1a01
+  sha256: f0b2e3f253b80e3d76f3d6ade48a5dcaaba384b6f6ae3dbd32cdffa697538860
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.1/maven-common-artifact-filters-1.1.pom
-  sha1: bc39234b0fae4008f14422bf02e710c1d86f667d
+  sha256: 471b4a0d14c7f019db66f3862aa40525455533fe10bf06d04aa85eac0ac91918
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.jar
-  sha1: 39036a83def48e0ba2a6b3f9ea082473b1ed4b5d
+  sha256: eabb4ba67917a8d5762f35f35314105bac2265588295c6b77a4feac9d210a336
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.3
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.pom
-  sha1: e28ce2f08d032ae25c83b9bde56df51e3420d6ff
+  sha256: 7587bc31ee5285debdb0b87b3446ccece28c2716820232adc0089295e84c265d
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-filtering/1.0-beta-2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.jar
-  sha1: 3eafeaced4cbc35e2a7bdb0c8ec4a82d881ab1d6
+  sha256: c83a954b12b7f7cd9cb9e8cee507aa30b38512c041c996f690274d7c18fb9ed5
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-filtering/1.0-beta-2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.pom
-  sha1: c4bbeb1f9e960134af0761a633fb37197ad97ec7
+  sha256: 6e0b7374c960c957deca066619b5cb0987f65f6a27ad88c32f50f7244939c12b
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-filtering/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar
-  sha1: c223ff4ef9e9b3b51b2c9310dda59527a4b85baf
+  sha256: 05fa641c31894ce930c6eb76ec1aa53a9de4cd9baa837fe492e9e0407099d226
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-filtering/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom
-  sha1: 58f9827f70cc29dd6aed2477b6384f14462f9576
+  sha256: 9f4bf710d0de3c4dde45182aae3d604784b4e2f91696e27f3411286ef96d181c
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-plugin-testing-harness/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-plugin-testing-harness/1.1/maven-plugin-testing-harness-1.1.jar
-  sha1: 42ead169ad52a71c11f150a5f43937ee2f4db8d9
+  sha256: 92e9f4feb7855b825f2eacf210bff51f63c13281d89c1520a7645f1ea94b2b0b
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-plugin-testing-harness/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-plugin-testing-harness/1.1/maven-plugin-testing-harness-1.1.pom
-  sha1: e7977710b7a48d4de3b770c3b7a5aafc370da62e
+  sha256: 3e82bced7eb460d4bab67700d32955feb27f400e2827b6b908dccc607205e88c
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-repository-builder/1.0-alpha-2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-repository-builder/1.0-alpha-2/maven-repository-builder-1.0-alpha-2.jar
-  sha1: 457ef0cfd457f6adba806dc1a8f642572959d7e1
+  sha256: b98e071e744a51f56a88adad29803fa7aedace672ed252da128e5b64db55fb89
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-repository-builder/1.0-alpha-2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-repository-builder/1.0-alpha-2/maven-repository-builder-1.0-alpha-2.pom
-  sha1: 1ec56ac2dbe2aa6376e7880479ee397c1a51c572
+  sha256: b8f92c499146980d88186202ec412aea4431f846f3f5634b935a9ac89ec0fdde
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/4/maven-shared-components-4.pom
-  sha1: 9d53a40e21554c2ea70743cdcb13cf33b11b24e0
+  sha256: 89ba78a4eef91456b28df9b0ed874e889d6ede135e6269d218964f5b2749d45e
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/6/maven-shared-components-6.pom
-  sha1: 1a3f779f2f4e644e95a30fe70b9724686e883848
+  sha256: 82d8e8844a07dc0ff0211a1bb6f90b2e717c73c846a239b7203964168f3add03
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/7/maven-shared-components-7.pom
-  sha1: b79520d942828dec5909f987aea19747f1729110
+  sha256: 4f0a6ebf2c0fa535e9861a95d6c6fe0a2d1090876021278b494d0aab9bd130db
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/8
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/8/maven-shared-components-8.pom
-  sha1: a6b88e9b00b5eea13069ce324293a85e427e57c6
+  sha256: a8d03f96ac58a1d00bad2ed7d251e3eda857c592a09e58d6bdb79d5e8626a316
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/10
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/10/maven-shared-components-10.pom
-  sha1: a7dabc7cff7b683d810e33a63c85cbc630c3ebf3
+  sha256: 833aa62469a7c812cccc5a572983d662a4a1805dcdc90ad0244ba159426ec00f
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/12
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/12/maven-shared-components-12.pom
-  sha1: bb93c9f13f4d000affb4425632ad00b2082049a3
+  sha256: 231a3c87248f98eed75cc32512adb5837b8141e52ba94af0fdb3e10292e1766e
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/17
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom
-  sha1: 9574bbf041ebae3dcf84c221d552dbeb01fe5b40
+  sha256: 4b96931a6d12491f858b44b2dbea50c1070c960232c041b966189dc905ac2631
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/18
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom
-  sha1: b9aa57e02b5452a9b6cc9147e40bb0b53a7c8009
+  sha256: a1d54fb81b5a8f197f5b3d0a928f63da2278c79bc8dd06e0be93593403f05775
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-components/19
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom
-  sha1: 650a49682d4c82f060c7cc8005f8734a5fd86af9
+  sha256: d82408269aada2eb1521ee8ff17f7c67333684f8ed2a09a9e35badd2e7575957
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-incremental/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar
-  sha1: 9d017a7584086755445c0a260dd9a1e9eae161a5
+  sha256: 61988e54486a5dc38f06c70fdae5b108556c63bd433697b9f4305fcdb30fa40e
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-incremental/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom
-  sha1: c607b2c64c027151c440f27b5ec86e062b9e9953
+  sha256: f21d19eb49b4a66cd85354a9ee7335439ea92a368173760a202766008cc19924
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-io/1.0
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.0/maven-shared-io-1.0.pom
-  sha1: 32a76cc4851e6d6471d9e2752fbcc2a74bf7475d
+  sha256: 6bfda76b551173eab2d355d5af547a916e2b66d9b393bbc2f7262c5a931d642a
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-io/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar
-  sha1: 02e1d57be05ecac7dbe56a3c73b113e98f22240f
+  sha256: 10c0b971d692d2e3026aec6c49cbb12ddee4214e2a727603d1d309779ca2a62b
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-io/1.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.pom
-  sha1: 031970802f3b9937e43a82ff11518e02a51669dc
+  sha256: ce42b015e3c2d6dafeb99763e360d0c0b08dfe054e204e944a23ddcc2463686a
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/0.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar
-  sha1: 5366d4739b5239472598227e80b97ad57f5d95e4
+  sha256: 86cd563b0bb40b0ef4e7183e41768049ad0afaca5b5acbf9680c53c217ca93d7
 - type: file
   dest: .m2/repository/org/apache/maven/shared/maven-shared-utils/0.1
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom
-  sha1: c638aa76e8eb374e14c4a3d25f66f36454645a54
+  sha256: 9ecb36b0e0d7d1d0f0dabd8705368b710df58b943091e9fa9071a29ccdc15a33
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.jar
-  sha1: 95c87b560b12e5217c40c408e643c49258c25ee4
+  sha256: 5fa774434507bea2edcf4496536c88f883926cc6baf121b5af172fa494aaa30d
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.pom
-  sha1: 9628d966cb4639e6dee0b68f2af8c97a9f7f16e0
+  sha256: 14df735a04e945f31198b4e9cbfddd103d238108d4f35bf77441216f0c4a4b29
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.12.4/surefire-2.12.4.pom
-  sha1: 1ebdae3514ea7f30a7c814146cf5962c25937a82
+  sha256: 71aeb7883b53ef63a5f6282f957dcfd09a6891707fe938b85939d814f2247e82
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-api/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.jar
-  sha1: 8d3cefe93510468ea493800ed70b269d5e44cee2
+  sha256: 84f6a8a5ca6072eee7b48592e3e491d7bb85f24faebbc5fcf4c745056d5d8dfb
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-api/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.pom
-  sha1: cf74a66f099e1ceb09e8c7b0e3037ecdd5e1ab6b
+  sha256: 58bc67922a9c370e59fbc592c5a7ee2ba17fd23d0ffdd58190e5c41358547123
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-booter/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.jar
-  sha1: eff97d818e540565b1ca0f152c43c17887713868
+  sha256: ad03864f1373c48da45ea25570e4950cd144fea7c08bd040f82f524ea4e1047f
 - type: file
   dest: .m2/repository/org/apache/maven/surefire/surefire-booter/2.12.4
   url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.pom
-  sha1: 7f01e7926a309628da09423400799204d448bba9
+  sha256: 1f52e6773f75a33eea6dc8803c1012b0f4cdafb030f087aa649559f90bf24dc9
 - type: file
   dest: .m2/repository/org/apache/maven/wagon/wagon/1.0-alpha-6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/1.0-alpha-6/wagon-1.0-alpha-6.pom
-  sha1: 69aa7db6cd9b32c6026dfb3d77d6a6865a2a9fc3
+  sha256: 36632b9cd41cc3010ac8f5c8cc2a015956f2256a4045c63d968898c1567b0eaf
 - type: file
   dest: .m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.jar
-  sha1: b3c986c63fc873fbaef75ad4e57cd162fd5c9dd6
+  sha256: a1e299e44d17d6eb67aacc4b5476bba4cbd4df7d1a16ef46ba9624e79d300c68
 - type: file
   dest: .m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6
   url: https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.pom
-  sha1: 1c1add559b9ed89168c2ae447481cfb63937ce2f
+  sha256: 0a752e52297e91d0d1266655e3058fda197fb3f0d9d37f01ac49053b223ccbc5
 - type: file
   dest: .m2/repository/org/apache/xbean/xbean/3.4
   url: https://repo.maven.apache.org/maven2/org/apache/xbean/xbean/3.4/xbean-3.4.pom
-  sha1: 6b6d0d977f3fb41cfd097a350472baefd82713f5
+  sha256: 56ab9c6c2d022a9b7079006ba500a996cd2c21411d53cac524933af20c5a4b99
 - type: file
   dest: .m2/repository/org/apache/xbean/xbean-reflect/3.4
   url: https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar
-  sha1: 26fd55dceb037f4789b399b22874d74f4d2db66f
+  sha256: 17e0efa187127034623197fb88c50c30d3baa62baa0f07d6ec693047ac92ec3b
 - type: file
   dest: .m2/repository/org/apache/xbean/xbean-reflect/3.4
   url: https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom
-  sha1: 5027123eb872a166f5205a5eb00d3ed186b63277
+  sha256: 01c97d4286dd3b5e5441faac3abb589f1fe123cea138bb4ae0995ffae14938df
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom
-  sha1: 06f66b2f7d2eef1d805c11bca91c89984cda4137
+  sha256: 2242fd02d12b1ca73267fb3d89863025517200e7a4ee426cba4667d0172c74c3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.5/plexus-1.0.5.pom
-  sha1: c1ea805e66e5fe377a79ff932cdd0ac70189fa39
+  sha256: 9a1df7db80ac85a4559a935404b9e57dc3dabeded5fb497d513dc51a1745e254
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.8
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.8/plexus-1.0.8.pom
-  sha1: 9e7c8432829962afe796b32587c1bfa841a317d5
+  sha256: a89a2f99088e244b3e52e35f19f5f7d3aba03dbb3cfaea044e2a694119e88f79
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.9
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.9/plexus-1.0.9.pom
-  sha1: 89d241b1e5ee6a72d3dd95d9eb90f635deebcdb2
+  sha256: 11a987607957fcac04d6ac182308abf5a7d3707f519863e55c8eb419953f5374
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.10
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom
-  sha1: 039c3f6a3cbe1f9e7b4a3309d9d7062b6e390fa7
+  sha256: 09b999a969e73525a6cc3ad2868ea744766e1d93b25c6c656d61a5ff9c881da9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.11
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom
-  sha1: 4693d4512d50c5159bef1c49def1d2690a327c30
+  sha256: 5197630dcd2336f5b4ab8e6d26e5b8675f5ebd83bd8c91d6aba431b09627d626
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.12
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.12/plexus-1.0.12.pom
-  sha1: 71d4361c71c7454a2626f3e18c789747256fe0b1
+  sha256: e3feb169478a21ea8e3af27f90b2d8551309ee771f24176e37ad48bbd7bdad04
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/2.0.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom
-  sha1: b6c97d19090baa51e953fb782e3986b068fb450f
+  sha256: e246e2a062b5d989fdefc521c9c56431ba5554ff8d2344edee9218a34a546a33
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/2.0.3
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom
-  sha1: bf472ec56fe823f1b4b997fe5b9396490ae9b1dc
+  sha256: fcc5670db8864c50c16bd96972f0da876f6651a8edc99850e68b2d569c5a4776
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/2.0.6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom
-  sha1: da193f47e5ce5a2cb85931851b3698e61cde8227
+  sha256: bea12e747708d25e73410ca1c731ebdfa102e8bdb6ec7d81bd4522583b234bcc
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/2.0.7
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom
-  sha1: f6ee62f8157f273757b8ffda59714a6a279a174d
+  sha256: 2b59062030ab0a15c5d0977ba22421706368926488739a65f25793e715cc8a74
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/3.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom
-  sha1: 9ae573423303ba80844ed564756442d32b97cc33
+  sha256: 1649f67caab553dd7e6b98002dcc670dab3f624c78f1259c8323e705b0c41e32
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/3.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.2/plexus-3.2.pom
-  sha1: 521733c90c6fb160311e47b51f0471642b69f64f
+  sha256: 1c7c732fdc37e7705af76835b1589fedd9db2abe1baa76b16bd061bd7291de4f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/3.3.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom
-  sha1: f081c65405b2d5e403c9d57e791b23f613966322
+  sha256: 6ec96f889bc29250f90b167c14e547f1b05aa23565c63f9079595befbde816bb
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-active-collections/1.0-beta-2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-active-collections/1.0-beta-2/plexus-active-collections-1.0-beta-2.jar
-  sha1: cfec67d79ff5a26bfd474340c115c4518340249d
+  sha256: 75fa462fdbd5f9ba3b629d3910c460f54dde55aafadc36ead5feef6181e7819e
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-active-collections/1.0-beta-2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-active-collections/1.0-beta-2/plexus-active-collections-1.0-beta-2.pom
-  sha1: 2f7e9cff33c5e6ecd553ac3cad919683a1dafe55
+  sha256: 51fd6215404edb9e390dde8b302fe17b59b6ba69331c65b1ed3260ff30c51a37
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/1.0-alpha-7
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-7/plexus-archiver-1.0-alpha-7.pom
-  sha1: 97b8b183d53cae882067c76b9448c92460040bf0
+  sha256: 9ece2108b5f3694fa2a240cafe232a0ff479120a8718cfcb2505f6110e0d47c9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/1.0-alpha-11
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-11/plexus-archiver-1.0-alpha-11.pom
-  sha1: 5bffae659f9f29e206da1ae5087e58f3f02fb577
+  sha256: 373734855a2ae0128e2ec84e8f9f6e8d6a3fe38dbcca8779e3dc13e035f90ae4
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/1.0-alpha-12
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-12/plexus-archiver-1.0-alpha-12.jar
-  sha1: 8fc9a2dd7608a0b5f5becf3a24618cb47ba2e34a
+  sha256: 20770300791d3734f8794a89a41316c238116338bcae0d7fc527349da5fea12a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/1.0-alpha-12
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/1.0-alpha-12/plexus-archiver-1.0-alpha-12.pom
-  sha1: 394f5fead974e82e41c155a4e29840d25b5e4f6b
+  sha256: d98edd0806de07079e8c31f7f90c8b96d3ffc6a92c293df215e8281b5abc152c
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/2.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar
-  sha1: 97853695be4bba3724512226c4d910fed733e608
+  sha256: 5a49a4c13e29da41c24bbb35b2f94b82bde259e25d4dd55ee3159e31d20677b8
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-archiver/2.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom
-  sha1: 8e63c83bf055cf0357669ca934f64c6bf27fc640
+  sha256: d2e14a5c6bed6ac4fc27d57f6ba227bb64a96742f71ee3fbafd2c019fa9d4449
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/1.2-alpha-6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/1.2-alpha-6/plexus-classworlds-1.2-alpha-6.pom
-  sha1: 1817585240d985682669c404c0170087ea1fc1bf
+  sha256: 6ddf6083d4449f11a0c15cc1c0b78ccb4fbcd9c167ec9ad29284d58e9e33a847
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/1.2-alpha-7
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/1.2-alpha-7/plexus-classworlds-1.2-alpha-7.pom
-  sha1: 6944ec0d0cab19adf167332f7197e045d64a577c
+  sha256: 2a0abfc63ed5c6216356255aa7c572723087938879934aca1ce11f17c24ce156
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar
-  sha1: 3a2bad2b58c1ca765d3f471cea8c1655d70fdfd9
+  sha256: 13a90763640e445ffa432ce9586e416572645c3ed4db6a860fe0d28256ad40ce
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom
-  sha1: df1dfb0099c8759b378fe0af3b4a564d2c16aa18
+  sha256: 6aad43eb7fee989d50f1ecaf4a8030c708f9c9ea3eb72ee023d76746ff89570a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom
-  sha1: 729ced1bbd17bbef54b720e6c4ef087d8adc4f6d
+  sha256: 1d94e9a3f048c9eaaba0016ea188a4e7029c6849b8708ff6dc900a34fe03c28c
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-api/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar
-  sha1: e9fe39d3b428df50637cccd434b414192e833754
+  sha256: b8c7f9f4ea32cee0263d6589bdeb617325edbf6c2930b3d5d1fb5c1442e545d3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-api/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.pom
-  sha1: e52bed1d095d713ed5e6cd1e732d084263802807
+  sha256: c50bb4169e2ae41d184b6507839100033bf6e86f54828829038aa0f7c8e89aa3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-javac/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar
-  sha1: 2f3de65bca1d5e6198d3839510a876b29af7b6fd
+  sha256: 03344d155153620b4de75d322d1b422701ac827dd0c631def1c7f46abf81386d
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-javac/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom
-  sha1: e8d65287b1679ec005284b62b92753eb29ba303c
+  sha256: 18a41342ece8d3016b4b5ec3e84b52331420413a17ce298574c1f61e26733955
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-manager/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar
-  sha1: e65c11400242a7a082f9f0d12ffec13dc26ab4c0
+  sha256: e5e201f06eca14b5268ec58003926552aea36b27492da20134c1a00ded6759bb
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compiler-manager/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom
-  sha1: 35b498aea8b90b9f8c9cd0af3bbb1b02412a5fd5
+  sha256: bf2aedb6f801096d0b7f9db201fef9ceb0696b801c446ada188144cae4e91dd2
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compilers/2.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom
-  sha1: ed2d72ba275a51ad8867ec230d2badcf45d0b3af
+  sha256: f6c8d1ee6e02ecd7376346b3f526e90b9e2c4d6128efa3b33cd463bcef8d480a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
-  sha1: c72f2660d0cbed24246ddb55d7fdc4f7374d2078
+  sha256: 4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom
-  sha1: fd506865d5d083d8cef9fdbf525ad99fcc3416c1
+  sha256: 815f3ec316b8c5fa701385fdf4009bfb51e07d780e8f6a6e2afe720c52d7e292
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-api/1.0-alpha-15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-api/1.0-alpha-15/plexus-component-api-1.0-alpha-15.pom
-  sha1: d6fb62fd5464884c7835d0b49d6427237571641c
+  sha256: 13c08c826418e737c907260e12ab2431ab5c5b833b65610d5adfbee7fcbbf937
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-component-api/1.0-alpha-16
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-api/1.0-alpha-16/plexus-component-api-1.0-alpha-16.pom
-  sha1: 53ad54acd9589c497ba54740f0455fec55db64d7
+  sha256: c254b481f6d50db6c2e15df5f027612c127a4408898e78904ffacb2c7e507bdc
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.1.6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.6/plexus-components-1.1.6.pom
-  sha1: 682713aa402653d0ea5e224870dc899803734519
+  sha256: 18468cef09449bc187a6d7c502cfbfad347a235129861ad138faeb87c2cda153
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.1.9
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.9/plexus-components-1.1.9.pom
-  sha1: 4fcb5bb11c1f4afa8cfc4a0cac8578e46a4dc072
+  sha256: f8c18b1a70bb21e3e62a750ebeec2ff4304049c390b33b0675dbd10b84bbe373
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.1.14
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom
-  sha1: aed78d67ee20a5038741c7cc2a8124ae20c960ad
+  sha256: 381d72c526be217b770f9f8c3f749a86d3b1548ac5c1fcb48d267530ec60d43f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.1.15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom
-  sha1: 44366f11d5b9571c16829ae7f0a7f20e116f6260
+  sha256: 7940cd305323b8409fdb7e78398f6efd8ff8a642c7dd8f353e519abe91ab0da3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.1.19
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom
-  sha1: 2c0f4d3bcbcdd8f77521502d886681ed5af38a25
+  sha256: d3e7f3adf5d002c01f362760ad1c2dce98e6354009a7c07c0a105c3eccb17159
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-components/1.3.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom
-  sha1: 4daaf2af8e09587eb3837b80252473d6f423c0f7
+  sha256: 8cbcb2aacd7f4a7759866ce91b2f910310fbe5a586b5fc7b9bdb76af9257e7c4
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-8
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-8/plexus-container-default-1.0-alpha-8.pom
-  sha1: 3324c2065311b5cd636d3fe37353fe7558a6ec22
+  sha256: b6617c2c7169b8d6c2440972e0d36e1265a80ed1d0def0263f1b400f4f3494a3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom
-  sha1: d00c65ec36fb3cc8c755182a7ee52d3d80340179
+  sha256: 8864b08e353614d0c4111f455f8b3907179f8b0be6c0845bc7f31ef6daf206ec
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar
-  sha1: 94aea3010e250a334d9dab7f591114cd6c767458
+  sha256: 7c758612888782ccfe376823aee7cdcc7e0cdafb097f7ef50295a0b0c3a16edf
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom
-  sha1: f557cb47f4594ac941d0edf08093a03ce15b51ba
+  sha256: ef71d45a49edfe76be0f520312a76bc2aae73ec0743a5ffffe10d30122c6e2b2
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-15/plexus-container-default-1.0-alpha-15.pom
-  sha1: 2fa665c1dad46cf92be2a73a5a0fcab95e80c9c8
+  sha256: 734a7a72d14604611991e1342cc3677eab4f974bf8f7fe73b54cf77f44169832
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-22
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-22/plexus-container-default-1.0-alpha-22.pom
-  sha1: e669c5d5be7111dc80fdea399881ff2a0201fc62
+  sha256: 05c646a3006f96aa1fe2e7d78dcf6bbb81252aee40eb9d83430da0bb423e98a5
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.5.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar
-  sha1: 0265fa2851d31c2e2177859a518987595efe146b
+  sha256: 69197486cd80beb54b4e0fcabaa325ec2d4e2636e9b245c472435c87a10931cf
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.5.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom
-  sha1: f68a6d3761cfdfdf1e13ce2c18327c514acad611
+  sha256: 3f0dc324ff65ccdbd6bb3df39136e2878047a2b0c19799689bcefa4132bdcba4
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.0-alpha-15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-15/plexus-containers-1.0-alpha-15.pom
-  sha1: 34357afac973e85e2eb35a1296c8b8bb55d00ffe
+  sha256: 1bd587c06afffc206cf70fddbd91637241118f81ffaf10d9e2c8bdefcc9781ee
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.0-alpha-16
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-16/plexus-containers-1.0-alpha-16.pom
-  sha1: 46b79dd7d6a8130d2fa81c80b16b695d491548fe
+  sha256: 85a1bef623d7f6158ed0bb34adb768147af5afab04d72239c313aaea91231c78
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.0-alpha-22
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-22/plexus-containers-1.0-alpha-22.pom
-  sha1: 05f2453473951b13b540c6793e8d64c8c7ae3533
+  sha256: c9db83cf13b16c2536a04c24187112c909b03e06228ca8be88f37cb1e65a9b22
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.0.3
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom
-  sha1: e16f1c9b83cdeb142fc038dd0262c61121d58c4b
+  sha256: 7c75075badcb014443ee94c8c4cad2f4a9905be3ce9430fe7b220afc7fa3a80f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.5.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom
-  sha1: cd786b660f8a4c1c520403a5fa04c7be45212b84
+  sha256: 1bc264824ec876b0ca6f4f5838175c541c638cbc43326a268b9aee7d4778b5ef
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar
-  sha1: 0a8f1178664a5457eef3f4531eb62f9505e1295f
+  sha256: 4f60eb379f93d8b616bc3b4d299f466bc54fcced959f7ad082dae78b89d6a3f0
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom
-  sha1: 1376ffcc4a8d46dee6c1a9096d0dcad3be01f838
+  sha256: 42aada809ec125bbfe4d38f9d196bbeb59f298b389df96e610269e369b8eb2c9
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.6/plexus-interpolation-1.6.pom
-  sha1: 849b6ca6d5694099fead0cd025df25ec813a4398
+  sha256: 4db9d2a93730f2d48ad492219d58c4e7620f9ac4687e6ee3bd54d7b91aa3d3de
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.7
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.7/plexus-interpolation-1.7.jar
-  sha1: f88cfdacd72b956de7557566cd78dd19d4a47e6e
+  sha256: 87520a457bee0e86085860e8d5baba9797dfe60057f6b5b5e5dbd15be0b6dd63
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.7
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.7/plexus-interpolation-1.7.pom
-  sha1: 5177e1957d8ba791b0a6e1e1d44efbee80146fee
+  sha256: 0fdd7d8954e33d94814f7c0419c8070179638ab31aedcb5667da4d0302812c06
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.11
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom
-  sha1: f03da80999422b6cc4300735789be83e4498a3bc
+  sha256: b84d281f59b9da528139e0752a0e1cab0bd98d52c58442b00e45c9748e1d9eee
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.12
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom
-  sha1: 101dd833f7186103b61a0281da38c95ae440eb63
+  sha256: 9e1d13d08550026de20cf8120b7e62e0ee842fc9df94140974c082b067fa5b72
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.13
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar
-  sha1: 1740038076cec1946fd28ed5ac5c1688f7cf7630
+  sha256: 8e149132ff32907f39560398e222f1733ae959cedd099b32ee31c7b9d3bc1d6f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.13
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom
-  sha1: 5003aac564f8ab42ceede81b114c520b48271873
+  sha256: e37731ea5ed19d276f33b77c93399fb5df026e1191133b15fbeab73342c6363b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar
-  sha1: d682b4b8c1a92329d5b114a51794ef178168abbe
+  sha256: 7111a4eb5f137781b68127a5a02d0208c28f26d2626fbd7a81d1172cd56449a8
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-interpolation/1.15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom
-  sha1: 3dda3be2ada841f5ca3976a48281349a99f27e89
+  sha256: 4a9f28e95f82a80fbd0632e6305b3c676f4d5e946f93028226d5365f53492bc7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/1.0-alpha-3
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/1.0-alpha-3/plexus-io-1.0-alpha-3.pom
-  sha1: f3f6e01756ecc77e2c5784ad7fd008e06be0b392
+  sha256: 6bc7fceccaabde91557f6a32a671d6c5a2e980bd817f2abbc07e8033db4788b3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/1.0-alpha-4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/1.0-alpha-4/plexus-io-1.0-alpha-4.jar
-  sha1: 3ff34059a7634f1e0a2aabc703592a2ac4a8f558
+  sha256: 68a108cfe167cbf956ecdb3d6d9f794ff3f87eebb7bef2b8936c3f67e914d93a
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/1.0-alpha-4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/1.0-alpha-4/plexus-io-1.0-alpha-4.pom
-  sha1: 3a566db2b7bd41cda47033e0142c39148047bc24
+  sha256: 96a4c8bf4446c22e9560009a4f3670425e83eec979b9ebdc15565b4fb6615de5
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/2.0.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar
-  sha1: 5d1890f1099242d6a1a6a46640eed931a96ef67f
+  sha256: e2f88c8813463aabfb1b689f0be551c24c58e8e5508fd5a44f8d20a327b1517f
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-io/2.0.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom
-  sha1: d0ad15a280e5bf6c32388cbef26fd7d428fa1623
+  sha256: 67a1ce072ad9ff4ce37985a1c32827eaeda4660cabe7f69eff2ca1ebff2d23bd
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.0.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom
-  sha1: a82e1ddd2d795616ac58d73ed246b8ec65326dfa
+  sha256: 36623a9539061d87f078af61ca62c3eacf422eb374641cf8903cdeb759671eb3
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.pom
-  sha1: 15492ecd00920daca9ec15f6acd695b626621e5b
+  sha256: e1772a8a6be92088ae069a3dd4f7c9dcbc0888434341028735da0f22481bcd47
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.2/plexus-utils-1.2.pom
-  sha1: f7c4dcf1d7602d7cefff308510c67316b215ce28
+  sha256: 71b8f080225e4a18aaeb18f43aab9a98bc76a6052d864e89eff79070b2b498c6
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.3
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.3/plexus-utils-1.3.pom
-  sha1: 050fadd040060c86cfd5d78ba95dab0cffcbcf5e
+  sha256: 29fd54ef49c7b404b091e87bb8726de50447d728b46c592fab0806ac9f6b113b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.4.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom
-  sha1: 0a77530df5e881e55a4ffaea4b6bf33d57bc5b26
+  sha256: 894261f5b21a2a18519537086181426450300385518e53d2555f5b4a6c1260e7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.4.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.2/plexus-utils-1.4.2.pom
-  sha1: f530a0f2aae3ef8e65ca359e7243d67ecc366076
+  sha256: 93d6675b2cf585c9c1148f1964156306c2573adfc1181c7219bd42a54a133771
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.4.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom
-  sha1: 0bdc8a7fbce7d9007a93d289a029b43e1196d85c
+  sha256: 687d05a9521ecb8e319e6beb46abcf53e0e61be647f1c7642a86e22f46814336
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.4.6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.6/plexus-utils-1.4.6.pom
-  sha1: a734ee9396d2ac09764cef74ebc56ef0339f6bd2
+  sha256: 6c68126854b084eed9b25ebc7dd08e965a3b0e73d7538fc750b4a56e44e7b920
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.4.9
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.9/plexus-utils-1.4.9.pom
-  sha1: c9aca88771038aaa06edb83a3af2ccc8e7048613
+  sha256: 06bb5b2a9138416ec6617cdd2afbfe7949be261f69bc6149c7de23e69b54a10c
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar
-  sha1: 342d1eb41a2bc7b52fa2e54e9872463fc86e2650
+  sha256: 72582f8ba285601fa753ceeda73ff3cbd94c6e78f52ec611621eaa0186165452
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.5.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom
-  sha1: 2a0b3470063440066d3b8a084340ce07dbdbfedc
+  sha256: e237bba8d1c65c171b5fe8774a2ff817525df6315b929a2085cf70cff15b1b58
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.5.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom
-  sha1: 6d04eaae6db5f8d879332da294a46df0fd81450f
+  sha256: f860675cad10e561bfa175d5717e2d8617d40c62321086ca4a85c006a0fa30d1
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.5.6
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.6/plexus-utils-1.5.6.pom
-  sha1: 2df1a6c4e7b1849a10643a37a6f66b21d49bd643
+  sha256: 0d473f85e79ae843569b9302f634fc3f70bdf135200ab2a486770f57deddbf39
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.5.8
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom
-  sha1: 7deaa90e5725075c9f9fb5a2cfbef75c86a5e5b5
+  sha256: 1ff4fb95c218af4a46f71d625212c70f377ccf97ad2e26cb8d4c10709265bf62
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.5.15
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom
-  sha1: b1f42bc7ebc5be3c0414f67fe2daf3b183acd74f
+  sha256: 12a3c9a32b82fdc95223cab1f9d344e14ef3e396da14c4d0013451646f3280e7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/2.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.1/plexus-utils-2.0.1.jar
-  sha1: 47f967db31c191f805eb835a510e9b128a37cacb
+  sha256: 1568f133d2611141a04d4d5c71d1f9913c1f2615ca6f2aab4b843357da454e3c
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/2.0.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.1/plexus-utils-2.0.1.pom
-  sha1: 0b923bc9618e8d657e0f642aac4eaccb2f3295ba
+  sha256: 5e436f4f8a223f6e41f103abad1bc4be3a48402cfb8dc6532f5a03e7bdb1c723
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/2.0.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar
-  sha1: 7841ba10ea46c9611ce702c3833ff9fccc8ae6eb
+  sha256: b4c51a337078b934ad656ee78a2d3a805a507129dc034692c67db0f94b659d3e
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/2.0.5
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom
-  sha1: 51785edd83de609389ba142c9516752a4246aefc
+  sha256: 35bc7d1213616236571072b2c56da18f7a57658de8b4a4100645b7054a2b273b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar
-  sha1: d63aa0daf60d573bada235e2b4207617dcf24959
+  sha256: e67fc0b78b5cbabe6748677ebec9844db5014ac397ab1537558bcd614b5c41e1
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.0
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom
-  sha1: fe3d8457b0cf4e219fd8e3edad5054b8e38f17b0
+  sha256: f479d0dc224974b50cfefae14344a4cd8b692b8dbf58df2d8c5c2f13db01d642
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.0.8
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar
-  sha1: faba5d28a07fcde50c8c26d3f002774acf11843e
+  sha256: 6c040032841fe6b23612c7a4b52347a4a115fdde748086c399a154b4b108e56b
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/3.0.8
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom
-  sha1: 45a8cbe47c297155f2e2ef10c1b7b4707ab55fc6
+  sha256: 0f0794dc7bdd60775d1b1e9bf70c55f2e4051bcd3d5e263a56c678080db3bbc1
 - type: file
   dest: .m2/repository/org/slf4j/jcl-over-slf4j/1.5.6
   url: https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom
-  sha1: 8aa25adef55174f1436073e551953c2f74a5c71b
+  sha256: d71d7748e68bb9cb7ad38b95d17c0466e31fc1f4d15bb1e635f3ebad34a38ff3
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-api/1.5.6
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom
-  sha1: b79729ffc12292c0ec755db12360486066f6fd34
+  sha256: 91b0a0d016b8c0cba1ddd8a5c59e5bf5c2a9b49b95577e8e38927a7fdff55ce8
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-jdk14/1.5.6
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom
-  sha1: cbc0f6b542435be20eba2fc698cf209e606ec1b4
+  sha256: 85f97344eeeed2714eda6f800aa712c1aa7405b0d7f98e207499363f82f37eec
 - type: file
   dest: .m2/repository/org/slf4j/slf4j-parent/1.5.6
   url: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom
-  sha1: 7e94cd535680417391d54c1b1a14bcf9ed29a400
+  sha256: b9d17d6f915b389c7dd77f170d6fcc77f1c7d6c7362fefb146043d8412defddd
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/3
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom
-  sha1: fdc1f6eb65f750775acd57ff4371d5657ae2e6d3
+  sha256: 03263b68791fb11e7464ffcc2c3de7eaeae235de8c94827ce6407e0454d2aae9
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/4
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom
-  sha1: 564f266ea9323e57e246f0fca8f04f596663fb86
+  sha256: 1838d132479005b4b7459b798e9d9915515090c288082fdcd86db0b10983a24c
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/5
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom
-  sha1: a557514263bbd4a6daef8f125ab80e78413292d3
+  sha256: e56188aa8ce51278006aa90bc7e0f304a81e2f1219f462e7d21f262535cd2795
 - type: file
   dest: .m2/repository/org/sonatype/forge/forge-parent/10
   url: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/10/forge-parent-10.pom
-  sha1: c24dc843444f348100c19ebd51157e7a5f61bfe7
+  sha256: c14fb9c32b59cc03251f609416db7c0cff01f811edcccb4f6a865d6e7046bd0b
 - type: file
   dest: .m2/repository/org/sonatype/oss/oss-parent/9
   url: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
-  sha1: e5cdc4d23b86d79c436f16fed20853284e868f65
+  sha256: fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a
 - type: file
   dest: .m2/repository/org/sonatype/plexus/plexus-build-api/0.0.4
   url: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar
-  sha1: 8fdcf45c2fad3052a51385fdfc79753d9124a1a7
+  sha256: d2d415ba26078a84e97816fd444361def86dec65a23b4278d95cfb1c285f2649
 - type: file
   dest: .m2/repository/org/sonatype/plexus/plexus-build-api/0.0.4
   url: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom
-  sha1: df389a276b6c493bcea1937339b29145a7ce99bf
+  sha256: 9bd824511766b9f512d7badbf24add39ece050c75e07d6cacc954517f49ea465
 - type: file
   dest: .m2/repository/org/sonatype/plexus/plexus-cipher/1.4
   url: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom
-  sha1: 8c0bee97c1badb926611bf82358e392fedc07764
+  sha256: a63a2e23988cca7fac6c93886d6f0506fd26d88d7e8cc0cb89b9c6e0d6c994ad
 - type: file
   dest: .m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3
   url: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom
-  sha1: b953c3a84a7d3f2a7f606e18c07ee38fb6766e3d
+  sha256: d5e650c50ef6958c028ed024b59af04cf3d38e1453a77d542b6b484bc0f4ca0b
 - type: file
   dest: .m2/repository/org/sonatype/spice/spice-parent/10
   url: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom
-  sha1: 8e0e4ba87d63321333c26494698377b1204633a8
+  sha256: 683c012c6bf5e1e31b232b3755c027ccd829692a09c8216652b414b09d4ae623
 - type: file
   dest: .m2/repository/org/sonatype/spice/spice-parent/12
   url: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom
-  sha1: e86b2d826f53093e27dc579bea3becbf1425d9ba
+  sha256: 21a19b26dbe5c38ddb5114cf4eadbf5ccb411bc6b128fdd5949b1ccb12f3683e
 - type: file
   dest: .m2/repository/org/sonatype/spice/spice-parent/16
   url: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/16/spice-parent-16.pom
-  sha1: aefd3135046b7c3f5835283bcc3b670fc46692b9
+  sha256: 258f43b5e805687302a5bb400856b972a573ec42a44f949641354a84b9243758
 - type: file
   dest: .m2/repository/org/sonatype/spice/spice-parent/17
   url: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/17/spice-parent-17.pom
-  sha1: 7f500699ef371383492a4d6ee799b1a77ffd82cc
+  sha256: 9151f9a5b33ec36ee8778842fc56144fb0242d39cbcc42061b053b8909969bdf
 - type: file
   dest: .m2/repository/org/xerial/sqlite-jdbc/3.25.2
   url: https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/3.25.2/sqlite-jdbc-3.25.2.jar
-  sha1: bd3c4cde613b661871e861eb56656c4c39e1ee0a
+  sha256: a45da61abed61568a533fdece125093180828edeb0d4b6f6d572e0cf457465f6
 - type: file
   dest: .m2/repository/org/xerial/sqlite-jdbc/3.25.2
   url: https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/3.25.2/sqlite-jdbc-3.25.2.pom
-  sha1: 3fa95370caaddae55ec04d53aae5999f202feb45
+  sha256: 5806cf36dd28bfe961f7fe12679f4a2748a03e7a1d0070c22c411c19f01f266a


### PR DESCRIPTION
Adds a patch that detects the default downloads folder (i.e. `xdg-download`), instead of defaulting to `$HOME`.

Also:

- Bump runtime to 22.08
- Update file hashes to sha256